### PR TITLE
fix: resolve #1 — Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration to keep Go module and GitHub Actions dependencies up to date automatically. Both ecosystems are checked on a weekly schedule.

## Changes

- Added `.github/dependabot.yml` with version 2 configuration
- Configured weekly update checks for `gomod` dependencies
- Configured weekly update checks for `github-actions` dependencies

Closes #1