### PR TITLE
refactor: Replace os.Kill with syscall.SIGTERM in signal handling

### DIFF
--- a/clix.go
+++ b/clix.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/charmbracelet/fang"
 	"github.com/spf13/cobra"
@@ -54,6 +55,6 @@ func (a *App) Run(cmd *cobra.Command) error {
 		context.Background(),
 		cmd,
 		fang.WithVersion(a.VersionString()),
-		fang.WithNotifySignal(os.Interrupt, os.Kill),
+		fang.WithNotifySignal(os.Interrupt, syscall.SIGTERM),
 	)
 }


### PR DESCRIPTION
In `clix.go:57`, `os.Kill` is passed to `fang.WithNotifySignal`. On Unix, `SIGKILL` cannot be caught or intercepted by a process — the kernel delivers it immediately. Passing it to `signal.Notify` (which fang wraps) is a silent no-op. This likely should be `syscall.SIGTERM`, which is the standard graceful-shutdown signal that *can* be caught. Change `os.Kill` to `syscall.SIGTERM` (adding `"syscall"` to imports) so the application actually handles termination signals for graceful shutdown.

---
*Automated improvement by yeti improvement-identifier*