### PR TITLE
refactor: Handle nil error in OutputJSONError to prevent panic

### DIFF
--- a/output.go
+++ b/output.go
@@ -2,6 +2,7 @@ package clix
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 )
@@ -20,12 +21,20 @@ func OutputJSON(data any) bool {
 
 // OutputJSONError writes a structured error object as JSON to stdout and
 // returns a wrapped error for the caller to propagate.
+// If err is nil, the message alone is used as the error text.
 func OutputJSONError(message string, err error) error {
+	details := message
+	if err != nil {
+		details = err.Error()
+	}
 	errOutput := map[string]any{
 		"error":   true,
 		"message": message,
-		"details": err.Error(),
+		"details": details,
 	}
 	_ = OutputJSON(errOutput)
-	return fmt.Errorf("%s: %w", message, err)
+	if err != nil {
+		return fmt.Errorf("%s: %w", message, err)
+	}
+	return errors.New(message)
 }

--- a/output_test.go
+++ b/output_test.go
@@ -80,3 +80,38 @@ func TestOutputJSONError(t *testing.T) {
 		t.Errorf("message = %v, want %q", got["message"], "deploy failed")
 	}
 }
+
+func TestOutputJSONError_NilError(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	JSONOutput = true
+	defer func() { JSONOutput = false }()
+
+	err := OutputJSONError("something went wrong", nil)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err == nil {
+		t.Fatal("OutputJSONError() returned nil error")
+	}
+	if err.Error() != "something went wrong" {
+		t.Errorf("error = %q, want %q", err.Error(), "something went wrong")
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	var got map[string]any
+	if jsonErr := json.Unmarshal(buf.Bytes(), &got); jsonErr != nil {
+		t.Fatalf("invalid JSON: %v", jsonErr)
+	}
+	if got["error"] != true {
+		t.Errorf("error field = %v, want true", got["error"])
+	}
+	if got["details"] != "something went wrong" {
+		t.Errorf("details = %v, want %q", got["details"], "something went wrong")
+	}
+}


### PR DESCRIPTION
In `output.go:28`, `OutputJSONError` calls `err.Error()` unconditionally. If a caller passes a nil `err`, this will panic with a nil pointer dereference. Since this is a public API function at a system boundary, it should guard against nil: either check `err != nil` before calling `.Error()` (using an empty string or the message itself as the details fallback), or document that nil is not accepted. A nil guard is the safer choice for a convenience library.

---
*Automated improvement by yeti improvement-identifier*