### PR TITLE
fix: resolve #3 — There are no configured CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v ./...
+
+  race:
+    name: Race Detection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests with race detector
+        run: go test -race -short ./...
+
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Verify go.mod is tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Check formatting
+        run: |
+          gofmt -l .
+          test -z "$(gofmt -l .)"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ fmt:
 
 ## lint: Run linter
 lint:
-	@golangci-lint run || echo "golangci-lint not installed, skipping"
+	@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint not installed, skipping"; exit 0; }
+	golangci-lint run
 
 ## test: Run tests
 test:


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow to run on pushes to `main` and on pull requests, resolving the lack of automated testing (#3). The workflow runs linting, unit tests, race detection, and module/format verification as parallel jobs. Also fixes the Makefile `lint` target to properly skip when `golangci-lint` is not installed instead of always running and masking failures.

## Changes

- Add `.github/workflows/ci.yml` with four parallel jobs: lint (golangci-lint), unit tests, race detection, and verify (go mod tidy, go vet, gofmt)
- All jobs use Go 1.26 on `ubuntu-latest`
- Fix Makefile `lint` target to check for `golangci-lint` before invoking it, ensuring a clean exit when absent and a real failure when the linter finds issues

Closes #3