### PR TITLE
refactor: Surface JSON encoding errors from OutputJSON instead of silently swallowing them

### DIFF
--- a/output.go
+++ b/output.go
@@ -9,14 +9,25 @@ import (
 
 // OutputJSON writes data as indented JSON to stdout if JSONOutput is true.
 // Returns true if output was written, false if JSON mode is not active.
-func OutputJSON(data any) bool {
+// If encoding fails, a fallback error envelope is written to stdout and the
+// encoding error is returned alongside true (output was still written).
+func OutputJSON(data any) (bool, error) {
 	if !JSONOutput {
-		return false
+		return false, nil
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(data)
-	return true
+	if err := enc.Encode(data); err != nil {
+		// Write a fallback error envelope so the "JSON was written" contract holds.
+		fallback := json.NewEncoder(os.Stdout)
+		fallback.SetIndent("", "  ")
+		_ = fallback.Encode(map[string]string{
+			"error":   "true",
+			"message": fmt.Sprintf("failed to encode JSON: %v", err),
+		})
+		return true, err
+	}
+	return true, nil
 }
 
 // OutputJSONError writes a structured error object as JSON to stdout and
@@ -32,7 +43,7 @@ func OutputJSONError(message string, err error) error {
 		"message": message,
 		"details": details,
 	}
-	_ = OutputJSON(errOutput)
+	_, _ = OutputJSON(errOutput)
 	if err != nil {
 		return fmt.Errorf("%s: %w", message, err)
 	}

--- a/output_test.go
+++ b/output_test.go
@@ -17,13 +17,16 @@ func TestOutputJSON_Active(t *testing.T) {
 	defer func() { JSONOutput = false }()
 
 	data := map[string]string{"key": "value"}
-	ok := OutputJSON(data)
+	ok, err := OutputJSON(data)
 
 	_ = w.Close()
 	os.Stdout = old
 
 	if !ok {
 		t.Error("OutputJSON() returned false when JSONOutput is true")
+	}
+	if err != nil {
+		t.Errorf("OutputJSON() returned unexpected error: %v", err)
 	}
 
 	var buf bytes.Buffer
@@ -40,9 +43,48 @@ func TestOutputJSON_Active(t *testing.T) {
 
 func TestOutputJSON_Inactive(t *testing.T) {
 	JSONOutput = false
-	ok := OutputJSON("anything")
+	ok, err := OutputJSON("anything")
 	if ok {
 		t.Error("OutputJSON() returned true when JSONOutput is false")
+	}
+	if err != nil {
+		t.Errorf("OutputJSON() returned unexpected error: %v", err)
+	}
+}
+
+func TestOutputJSON_EncodeError(t *testing.T) {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	JSONOutput = true
+	defer func() { JSONOutput = false }()
+
+	// Channels cannot be JSON-encoded.
+	ok, err := OutputJSON(make(chan int))
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if !ok {
+		t.Error("OutputJSON() returned false on encode error; expected true (fallback written)")
+	}
+	if err == nil {
+		t.Fatal("OutputJSON() returned nil error for unencodable type")
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	var got map[string]string
+	if jsonErr := json.Unmarshal(buf.Bytes(), &got); jsonErr != nil {
+		t.Fatalf("fallback output is not valid JSON: %v\nraw: %s", jsonErr, buf.String())
+	}
+	if got["error"] != "true" {
+		t.Errorf("error field = %q, want %q", got["error"], "true")
+	}
+	if got["message"] == "" {
+		t.Error("fallback message is empty")
 	}
 }
 


### PR DESCRIPTION
In `output.go:18`, `OutputJSON` discards the error from `enc.Encode(data)` with `_ = enc.Encode(data)` and returns `true` (indicating output was written successfully) even if encoding fails. This can happen when callers pass unencodable types (e.g., channels, functions, or structs with cycles). The function's `bool` return signals "JSON was written" to the caller, who then skips text output — so a silent encode failure means the user sees *no output at all*.

Change `OutputJSON` to return `(bool, error)` so callers can detect and handle encoding failures. Alternatively, at minimum, write a fallback error JSON envelope to stdout when encoding fails, so the "JSON was written" contract of returning `true` is actually honored. Update the call site in `OutputJSONError` (`output.go:35`) accordingly.

---
*Automated improvement by yeti improvement-identifier*